### PR TITLE
Improve logging, error surfacing, and provider/LLM configuration

### DIFF
--- a/lutum-desktop/src/components/Chat.tsx
+++ b/lutum-desktop/src/components/Chat.tsx
@@ -9,7 +9,7 @@ import { Sidebar } from "./Sidebar";
 import { MessageList } from "./MessageList";
 import { InputBar } from "./InputBar";
 import { Settings } from "./Settings";
-import { useBackend } from "../hooks/useBackend";
+import { useBackend, type LogEvent } from "../hooks/useBackend";
 import { initDarkMode, loadSettings, PROVIDER_CONFIG } from "../stores/settings";
 import { t, type Language } from "../i18n/translations";
 import {
@@ -494,6 +494,22 @@ export function Chat() {
     }));
   }, []);
 
+  const addLogMessage = useCallback(
+    (sessionId: string, event: LogEvent) => {
+      const details = event.full && event.full !== event.message ? `\n\n${event.full}` : "";
+      const logMsg: Message = {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        content: `${event.message}${details}`,
+        timestamp: new Date().toISOString(),
+        type: "log",
+        logLevel: event.level === "ERROR" ? "error" : "warning",
+      };
+      addMessage(sessionId, logMsg);
+    },
+    [addMessage]
+  );
+
   // Send message handler - Phase-basiert
   const handleSend = useCallback(
     async (content: string) => {
@@ -531,6 +547,7 @@ export function Chat() {
 
         // Pipeline mit Status-Callback für Live-Updates und Sources-Callback für URLs
         const settings = loadSettings();
+        const baseUrl = PROVIDER_CONFIG[settings.provider].baseUrl;
         const pipelineResult = await runPipeline(
           content,
           settings.apiKey,
@@ -550,10 +567,13 @@ export function Chat() {
             };
             addMessage(sessionId, sourcesMsg);
           },
-          undefined,  // onLog - not used in pipeline
+          (event) => addLogMessage(sessionId, event),
           modelSize,
           academicMode,
-          language
+          language,
+          settings.provider,
+          settings.workModel,
+          baseUrl
         );
 
         // Session-Titel vom LLM
@@ -590,6 +610,7 @@ export function Chat() {
         if (!ctx) return;
 
         const settings = loadSettings();
+        const baseUrl = PROVIDER_CONFIG[settings.provider].baseUrl;
         const planResult = await createPlan(
           ctx.user_query,
           ctx.clarification_questions,
@@ -597,7 +618,10 @@ export function Chat() {
           settings.apiKey,
           sessionId,
           modelSize,
-          academicMode
+          academicMode,
+          settings.provider,
+          settings.workModel,
+          baseUrl
         );
 
         // Check für Normal Mode (plan_points) ODER Academic Mode (academic_bereiche)
@@ -639,7 +663,18 @@ export function Chat() {
 
         // User will Plan ändern
         const settings = loadSettings();
-        const reviseResult = await revisePlan(ctx, content, settings.apiKey, sessionId, modelSize, academicMode);
+        const baseUrl = PROVIDER_CONFIG[settings.provider].baseUrl;
+        const reviseResult = await revisePlan(
+          ctx,
+          content,
+          settings.apiKey,
+          sessionId,
+          modelSize,
+          academicMode,
+          settings.provider,
+          settings.workModel,
+          baseUrl
+        );
 
         // Check für Normal Mode (plan_points) ODER Academic Mode (academic_bereiche)
         const hasNormalPlan = reviseResult?.plan_points && reviseResult.plan_points.length > 0;
@@ -666,7 +701,7 @@ export function Chat() {
         }
       }
     },
-    [sessionsState.activeSessionId, activeSession, runPipeline, createPlan, revisePlan, updateSession, addMessage]
+    [sessionsState.activeSessionId, activeSession, runPipeline, createPlan, revisePlan, updateSession, addMessage, addLogMessage]
   );
 
   // Handler: "Los geht's" Button → Deep Research starten
@@ -680,6 +715,7 @@ export function Chat() {
     updateSession(sessionId, { phase: "researching" });
 
     const settings = loadSettings();
+    const baseUrl = PROVIDER_CONFIG[settings.provider].baseUrl;
 
     // === ACADEMIC MODE: Hierarchische Bereiche mit Meta-Synthese ===
     if (academicMode && ctx.academic_bereiche && Object.keys(ctx.academic_bereiche).length > 0) {
@@ -770,11 +806,12 @@ export function Chat() {
           };
           addMessage(sessionId, metaMsg);
         },
-        undefined,  // onLog - not used currently
+        (event) => addLogMessage(sessionId, event),
+        settings.provider,
         settings.workModel,
         settings.finalModel,
         language,
-        PROVIDER_CONFIG[settings.provider].baseUrl
+        baseUrl
       );
 
       // Ergebnis verarbeiten
@@ -875,13 +912,14 @@ export function Chat() {
         };
         addMessage(sessionId, synthMsg);
       },
-      undefined,  // onLog - not used currently
+      (event) => addLogMessage(sessionId, event),
       modelSize,
       academicMode,
+      settings.provider,
       settings.workModel,
       settings.finalModel,
       language,
-      PROVIDER_CONFIG[settings.provider].baseUrl
+      baseUrl
     );
 
     // Finale Response
@@ -927,7 +965,7 @@ export function Chat() {
       addMessage(sessionId, errorMsg);
       updateSession(sessionId, { phase: "planning" }); // Back to Planning
     }
-  }, [activeSession, runDeepResearch, runAcademicResearch, updateSession, addMessage, academicMode, language]);
+  }, [activeSession, runDeepResearch, runAcademicResearch, updateSession, addMessage, addLogMessage, academicMode, language]);
 
   // Handler: "Edit plan" button → User can enter changes
   const handleEditPlan = useCallback(() => {
@@ -984,9 +1022,11 @@ export function Chat() {
 
         // Automatisch fortsetzen
         const settings = loadSettings();
+        const baseUrl = PROVIDER_CONFIG[settings.provider].baseUrl;
         await resumeSession(
           result.session_id,
           settings.apiKey,
+          settings.provider,
           settings.workModel,
           settings.finalModel,
           // onStatus
@@ -1025,7 +1065,9 @@ export function Chat() {
               timestamp: new Date().toISOString(),
             };
             addMessage(sessionId, synthMsg);
-          }
+          },
+          (event) => addLogMessage(sessionId, event),
+          baseUrl
         );
 
         updateSession(sessionId, { phase: "done" });
@@ -1052,7 +1094,7 @@ export function Chat() {
       };
       addMessage(sessionId, errorMsg);
     }
-  }, [activeSession, recoverSession, resumeSession, addMessage, updateSession, language, setCurrentStatus]);
+  }, [activeSession, recoverSession, resumeSession, addMessage, addLogMessage, updateSession, language, setCurrentStatus]);
 
   return (
     <div className="h-screen flex bg-[var(--bg-primary)] overflow-hidden">

--- a/lutum-desktop/src/components/MessageList.tsx
+++ b/lutum-desktop/src/components/MessageList.tsx
@@ -106,7 +106,9 @@ export interface Message {
   url?: string;
   loading?: boolean;
   /** Spezial-Typ für verschiedene Anzeigen */
-  type?: "text" | "plan" | "sources" | "point_summary" | "synthesis_waiting" | "sources_registry";
+  type?: "text" | "plan" | "sources" | "point_summary" | "synthesis_waiting" | "sources_registry" | "log";
+  /** Log Level für log-Nachrichten */
+  logLevel?: "warning" | "error";
   /** URLs für sources-Typ */
   sources?: string[];
   /** Source Registry für klickbare Citations {1: "url1", 2: "url2"} */
@@ -719,7 +721,20 @@ export function MessageList({ messages, loading, onStartResearch, onEditPlan, on
               )}
 
               {/* Point Summary Box - Special rendering */}
-              {msg.type === "point_summary" && msg.pointTitle ? (
+              {msg.type === "log" ? (
+                <div
+                  className={`rounded-xl border px-4 py-3 text-sm ${
+                    msg.logLevel === "error"
+                      ? "border-red-500/40 bg-red-500/10 text-red-200"
+                      : "border-amber-400/40 bg-amber-400/10 text-amber-200"
+                  }`}
+                >
+                  <div className="text-xs font-semibold uppercase tracking-wide mb-2 opacity-80">
+                    {msg.logLevel === "error" ? "Backend Error" : "Backend Warnung"}
+                  </div>
+                  <MarkdownContent content={msg.content} isUser={false} />
+                </div>
+              ) : msg.type === "point_summary" && msg.pointTitle ? (
                 <PointSummaryBox
                   pointTitle={msg.pointTitle}
                   pointNumber={msg.pointNumber || 1}

--- a/lutum-desktop/src/hooks/useBackend.ts
+++ b/lutum-desktop/src/hooks/useBackend.ts
@@ -46,6 +46,9 @@ function getUserFriendlyError(error: unknown): string {
   if (lowerMsg.includes('api key') || lowerMsg.includes('api_key')) {
     return 'Problem mit dem API-Key. Bitte in den Einstellungen überprüfen.';
   }
+  if (lowerMsg.includes('model not found') || lowerMsg.includes('unknown model')) {
+    return 'Das Modell wurde nicht gefunden. Bitte prüfe den Modellnamen in den Einstellungen.';
+  }
   if (lowerMsg.includes('quota') || lowerMsg.includes('credits')) {
     return 'API-Kontingent aufgebraucht. Bitte API-Key-Guthaben prüfen.';
   }
@@ -265,14 +268,32 @@ export function useBackend() {
    * Gibt session_title zurück für Session-Benennung.
    */
   const startResearch = useCallback(
-    async (message: string, apiKey: string, sessionId?: string, modelSize: string = 'small', academicMode: boolean = false): Promise<OverviewResponse | null> => {
+    async (
+      message: string,
+      apiKey: string,
+      sessionId?: string,
+      modelSize: string = 'small',
+      academicMode: boolean = false,
+      provider: string = 'openrouter',
+      workModel: string = 'google/gemini-2.5-flash-lite-preview-09-2025',
+      baseUrl: string = 'https://openrouter.ai/api/v1/chat/completions'
+    ): Promise<OverviewResponse | null> => {
       setState((s) => ({ ...s, loading: true, error: null }));
 
       try {
         const response = await fetch(`${BACKEND_URL}/research/overview`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ message, api_key: apiKey, session_id: sessionId, model_size: modelSize, academic_mode: academicMode }),
+          body: JSON.stringify({
+            message,
+            api_key: apiKey,
+            session_id: sessionId,
+            model_size: modelSize,
+            academic_mode: academicMode,
+            provider,
+            work_model: workModel,
+            base_url: baseUrl,
+          }),
         });
 
         if (!response.ok) {
@@ -312,7 +333,10 @@ export function useBackend() {
       onLog?: (event: LogEvent) => void,
       modelSize: string = 'small',
       academicMode: boolean = false,
-      language: string = 'de'
+      language: string = 'de',
+      provider: string = 'openrouter',
+      workModel: string = 'google/gemini-2.5-flash-lite-preview-09-2025',
+      baseUrl: string = 'https://openrouter.ai/api/v1/chat/completions'
     ): Promise<PipelineResponse | null> => {
       setState((s) => ({ ...s, loading: true, error: null }));
 
@@ -320,7 +344,18 @@ export function useBackend() {
         const response = await fetch(`${BACKEND_URL}/research/run`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ message, api_key: apiKey, session_id: sessionId, max_step: 3, model_size: modelSize, academic_mode: academicMode, language: language }),
+          body: JSON.stringify({
+            message,
+            api_key: apiKey,
+            session_id: sessionId,
+            max_step: 3,
+            model_size: modelSize,
+            academic_mode: academicMode,
+            language: language,
+            provider,
+            work_model: workModel,
+            base_url: baseUrl,
+          }),
         });
 
         if (!response.ok) {
@@ -397,7 +432,10 @@ export function useBackend() {
       apiKey: string,
       sessionId?: string,
       modelSize: string = 'small',
-      academicMode: boolean = false
+      academicMode: boolean = false,
+      provider: string = 'openrouter',
+      workModel: string = 'google/gemini-2.5-flash-lite-preview-09-2025',
+      baseUrl: string = 'https://openrouter.ai/api/v1/chat/completions'
     ): Promise<PlanResponse | null> => {
       setState((s) => ({ ...s, loading: true, error: null }));
 
@@ -413,6 +451,9 @@ export function useBackend() {
             session_id: sessionId,
             model_size: modelSize,
             academic_mode: academicMode,
+            provider,
+            work_model: workModel,
+            base_url: baseUrl,
           }),
         });
 
@@ -449,7 +490,10 @@ export function useBackend() {
       apiKey: string,
       sessionId?: string,
       modelSize: string = 'small',
-      academicMode: boolean = false
+      academicMode: boolean = false,
+      provider: string = 'openrouter',
+      workModel: string = 'google/gemini-2.5-flash-lite-preview-09-2025',
+      baseUrl: string = 'https://openrouter.ai/api/v1/chat/completions'
     ): Promise<PlanResponse | null> => {
       setState((s) => ({ ...s, loading: true, error: null }));
 
@@ -464,6 +508,9 @@ export function useBackend() {
             session_id: sessionId,
             model_size: modelSize,
             academic_mode: academicMode,
+            provider,
+            work_model: workModel,
+            base_url: baseUrl,
           }),
         });
 
@@ -506,6 +553,7 @@ export function useBackend() {
       onLog?: (event: LogEvent) => void,
       modelSize: string = 'small',
       academicMode: boolean = false,
+      provider: string = 'openrouter',
       workModel: string = 'google/gemini-2.5-flash-lite-preview-09-2025',
       finalModel: string = 'qwen/qwen3-vl-235b-a22b-instruct',
       language: string = 'de',
@@ -523,6 +571,7 @@ export function useBackend() {
             session_id: sessionId,
             model_size: modelSize,
             academic_mode: academicMode,
+            provider,
             work_model: workModel,
             final_model: finalModel,
             language: language,
@@ -628,6 +677,7 @@ export function useBackend() {
       onBereichComplete?: (event: BereichCompleteEvent) => void,
       onMetaSynthesisStart?: (event: MetaSynthesisStartEvent) => void,
       onLog?: (event: LogEvent) => void,
+      provider: string = 'openrouter',
       workModel: string = 'google/gemini-2.5-flash-lite-preview-09-2025',
       finalModel: string = 'qwen/qwen3-vl-235b-a22b-instruct',
       language: string = 'de',
@@ -643,6 +693,7 @@ export function useBackend() {
             context_state: contextState,
             api_key: apiKey,
             session_id: sessionId,
+            provider,
             work_model: workModel,
             final_model: finalModel,
             language: language,
@@ -810,6 +861,7 @@ export function useBackend() {
   const resumeSession = useCallback(async (
     sessionId: string,
     apiKey: string,
+    provider: string = 'openrouter',
     workModel: string = 'google/gemini-2.5-flash-lite-preview-09-2025',
     finalModel: string = 'qwen/qwen3-vl-235b-a22b-instruct',
     onStatus?: (status: string) => void,
@@ -828,6 +880,7 @@ export function useBackend() {
         body: JSON.stringify({
           session_id: sessionId,
           api_key: apiKey,
+          provider,
           work_model: workModel,
           final_model: finalModel,
           base_url: baseUrl,

--- a/lutum-desktop/src/stores/sessions.ts
+++ b/lutum-desktop/src/stores/sessions.ts
@@ -13,7 +13,9 @@ export interface Message {
   timestamp: string; // ISO string für JSON serialization
   url?: string;
   /** Spezial-Typ für verschiedene Anzeigen */
-  type?: "text" | "plan" | "sources" | "point_summary" | "synthesis_waiting" | "sources_registry";
+  type?: "text" | "plan" | "sources" | "point_summary" | "synthesis_waiting" | "sources_registry" | "log";
+  /** Log Level für log-Nachrichten */
+  logLevel?: "warning" | "error";
   /** URLs für sources-Typ (aufklappbare Quellen-Box) */
   sources?: string[];
   /** Source Registry für klickbare Citations {1: "url1", 2: "url2"} */

--- a/lutum/core/api_config.py
+++ b/lutum/core/api_config.py
@@ -14,6 +14,33 @@ Usage:
 """
 
 _OPENROUTER_API_KEY: str = ""
+_PROVIDER: str = "openrouter"
+_BASE_URL: str = "https://openrouter.ai/api/v1/chat/completions"
+_WORK_MODEL: str = "google/gemini-2.5-flash-lite-preview-09-2025"
+_FINAL_MODEL: str = "qwen/qwen3-vl-235b-a22b-instruct"
+
+PROVIDER_CONFIG = {
+    "openrouter": {
+        "name": "OpenRouter",
+        "base_url": "https://openrouter.ai/api/v1/chat/completions",
+    },
+    "openai": {
+        "name": "OpenAI",
+        "base_url": "https://api.openai.com/v1/chat/completions",
+    },
+    "anthropic": {
+        "name": "Anthropic",
+        "base_url": "https://api.anthropic.com/v1/messages",
+    },
+    "google": {
+        "name": "Google Gemini",
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+    },
+    "huggingface": {
+        "name": "HuggingFace",
+        "base_url": "https://api-inference.huggingface.co/v1/chat/completions",
+    },
+}
 
 
 def set_api_key(key: str) -> None:
@@ -22,6 +49,70 @@ def set_api_key(key: str) -> None:
     _OPENROUTER_API_KEY = key or ""
 
 
+def set_api_config(
+    key: str,
+    provider: str = "openrouter",
+    work_model: str | None = None,
+    final_model: str | None = None,
+    base_url: str | None = None
+) -> None:
+    """Setzt API Konfiguration (Provider, Models, Base URL)."""
+    global _OPENROUTER_API_KEY, _PROVIDER, _BASE_URL, _WORK_MODEL, _FINAL_MODEL
+
+    _OPENROUTER_API_KEY = key or ""
+    _PROVIDER = provider or "openrouter"
+
+    config = PROVIDER_CONFIG.get(_PROVIDER)
+    if base_url:
+        _BASE_URL = base_url
+    elif config:
+        _BASE_URL = config["base_url"]
+
+    if work_model:
+        _WORK_MODEL = work_model
+    if final_model:
+        _FINAL_MODEL = final_model
+
+
 def get_api_key() -> str:
     """Holt den API Key."""
     return _OPENROUTER_API_KEY
+
+
+def get_provider() -> str:
+    """Aktuellen Provider holen."""
+    return _PROVIDER
+
+
+def get_api_base_url() -> str:
+    """Aktuelle Base URL holen."""
+    return _BASE_URL
+
+
+def get_work_model() -> str:
+    """Aktuelles Work Model holen."""
+    return _WORK_MODEL
+
+
+def get_final_model() -> str:
+    """Aktuelles Final Model holen."""
+    return _FINAL_MODEL
+
+
+def get_api_headers() -> dict:
+    """Standard Headers für API-Calls basierend auf Provider."""
+    headers = {
+        "Content-Type": "application/json",
+    }
+
+    if _OPENROUTER_API_KEY:
+        headers["Authorization"] = f"Bearer {_OPENROUTER_API_KEY}"
+
+    if _PROVIDER == "google" and _OPENROUTER_API_KEY:
+        headers["x-goog-api-key"] = _OPENROUTER_API_KEY
+
+    if _PROVIDER == "anthropic" and _OPENROUTER_API_KEY:
+        headers["x-api-key"] = _OPENROUTER_API_KEY
+        headers.setdefault("anthropic-version", "2023-06-01")
+
+    return headers

--- a/lutum/core/llm_client.py
+++ b/lutum/core/llm_client.py
@@ -1,0 +1,101 @@
+"""
+LLM Client Helpers
+==================
+Zentrale Helpers für API-Calls + Error Parsing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import requests
+
+from lutum.core.api_config import get_api_base_url, get_api_headers, get_provider
+from lutum.core.log_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class LLMCallResult:
+    content: Optional[str]
+    error: Optional[str]
+    raw: Optional[dict[str, Any]]
+
+
+def _extract_error_message(payload: Any, status_code: Optional[int] = None) -> str:
+    if isinstance(payload, dict):
+        if "error" in payload:
+            error = payload["error"]
+            if isinstance(error, dict):
+                message = error.get("message") or error.get("error") or str(error)
+            else:
+                message = str(error)
+        else:
+            message = payload.get("message") or payload.get("detail") or str(payload)
+    else:
+        message = str(payload)
+
+    if status_code:
+        return f"HTTP {status_code}: {message}"
+    return message
+
+
+def call_chat_completion(
+    messages: list[dict[str, str]],
+    model: str,
+    max_tokens: int,
+    timeout: int,
+    base_url: Optional[str] = None
+) -> LLMCallResult:
+    """
+    Führt einen Chat-Completion Call durch (OpenAI-kompatibles Format).
+    """
+    url = base_url or get_api_base_url()
+
+    try:
+        response = requests.post(
+            url,
+            headers=get_api_headers(),
+            json={
+                "model": model,
+                "messages": messages,
+                "max_tokens": max_tokens
+            },
+            timeout=timeout
+        )
+
+        if not response.ok:
+            try:
+                payload = response.json()
+            except ValueError:
+                payload = response.text
+            error_message = _extract_error_message(payload, response.status_code)
+            logger.error(f"LLM API error ({get_provider()}): {error_message}")
+            return LLMCallResult(content=None, error=error_message, raw=None)
+
+        result = response.json()
+        if "choices" not in result:
+            error_message = _extract_error_message(result, response.status_code)
+            logger.error(f"LLM response missing choices: {error_message}")
+            return LLMCallResult(content=None, error=error_message, raw=result)
+
+        choice = result["choices"][0]
+        message = choice.get("message", {})
+        content = message.get("content")
+        if content is None or not str(content).strip():
+            finish_reason = choice.get("finish_reason", "unknown")
+            refusal = message.get("refusal", "none")
+            logger.warning(f"LLM returned empty content (finish_reason={finish_reason}, refusal={refusal}, model={model})")
+
+        return LLMCallResult(content=content, error=None, raw=result)
+
+    except requests.Timeout:
+        error_message = "LLM timeout"
+        logger.error(error_message)
+        return LLMCallResult(content=None, error=error_message, raw=None)
+    except Exception as e:
+        error_message = f"LLM call failed: {e}"
+        logger.error(error_message)
+        return LLMCallResult(content=None, error=error_message, raw=None)

--- a/lutum/researcher/scraper.py
+++ b/lutum/researcher/scraper.py
@@ -200,4 +200,4 @@ if __name__ == "__main__":
     print(f"\nSuccess: {result['success_count']}/{len(test_urls)}")
 
     if result["error"]:
-        print(f"Error: {result['error']}")
+        logger.error("Error: %s", result["error"])


### PR DESCRIPTION
### Motivation
- Centralize and harden logging so WARN/ERROR are captured, persisted and can be streamed to the frontend for user-visible diagnostics.
- Replace ad-hoc LLM HTTP calls with a single client that normalizes errors and allows multiple providers/models/base URLs to be configured at runtime.
- Surface backend warnings/errors to the UI so users see actionable messages and can report reproducible issues.

### Description
- Add a centralized logging setup with a daily rotating file handler and a live WARN/ERROR buffer used to stream log events to the frontend, plus `setup_logging()` called at backend startup (`lutum/core/log_config.py`, `lutum-backend/main.py`).
- Introduce a runtime API/provider configuration module with provider/model/base-url storage and helper headers (`lutum/core/api_config.py`), and wire endpoints to call `set_api_config(...)` from incoming requests so provider/model/base_url are honored per request (`lutum-backend/routes/*.py`).
- Add an LLM client wrapper `call_chat_completion()` that centralizes HTTP calls and error parsing for OpenRouter/OpenAI/Anthropic/Google/HuggingFace style endpoints (`lutum/core/llm_client.py`) and replace many direct `requests.post` usages to use this client and the configured model (`lutum/researcher/*` changes).
- Surface backend log events into the desktop UI by: forwarding the live log buffer from streaming endpoints, adding a `log` message type and UI rendering for warning/error boxes, and plumbing onLog handlers end-to-end between backend SSE/ndjson streams and the React frontend (`lutum-desktop/src/hooks/useBackend.ts`, `lutum-desktop/src/components/Chat.tsx`, `MessageList.tsx`, `stores/sessions.ts`).
- Improve error handling consistenty: replace stray `print()` calls with `logger.*`, return clearer LLM error messages upstream, and flush buffered logs into pipeline streams before emitting final error responses (`lutum/researcher/*`, `lutum-backend/routes/research.py`).

### Testing
- Started the frontend dev server to validate UI changes with `npm run dev` in `l u t u m-desktop`, which came up successfully (Vite dev server ready). (success)
- Ran a headless Playwright script to inject demo sessions and capture a screenshot demonstrating backend log messages rendering in the chat UI; the script produced `artifacts/log-messages.png` confirming the new `log` message rendering. (success)
- Performed `npm install` to ensure frontend deps resolve; install completed without errors. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d0c59f1e4832f96459093b99263e9)